### PR TITLE
K.coalesce fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "meshzoo",
     "pyamg",
     "pyvista",
-    "scipy",
+    "scipy~=1.15.0",
     "tqdm",
     "torch",
     "trame",

--- a/src/torchfem/base.py
+++ b/src/torchfem/base.py
@@ -192,7 +192,7 @@ class FEM(ABC):
 
             K += torch.sparse_coo_tensor(indices, values, size=size).coalesce()
 
-        return K
+        return K.coalesce()
 
     def assemble_force(self, f: Tensor) -> Tensor:
         """Assemble global force vector."""
@@ -275,7 +275,9 @@ class FEM(ABC):
 
                 # Print iteration information
                 if verbose:
-                    print(f"Increment {n} | Iteration {i+1} | Residual: {res_norm:.5e}")
+                    print(
+                        f"Increment {n} | Iteration {i + 1} | Residual: {res_norm:.5e}"
+                    )
 
                 # Check convergence
                 if res_norm < rtol * res_norm0 or res_norm < atol:


### PR DESCRIPTION
Not sure if/how you'd like contributions, happy to use another approach if preferred. Two small changes:

-  Bug fix on K.coalesce:
  `K += torch.sparse_coo_tensor(indices, values, size=size).coalesce()` results in a coalesced tensor on cpu, uncoalesced on cuda ([I've raised this issue on PyTorch](https://github.com/pytorch/pytorch/issues/146976)). Without running `K.coalesce` after the chunk iteration the gradients from cuda can be wrong.

  Example code:
  ```python
  import sys
  
  import torch
  from torchfem import Solid
  from torchfem.materials import IsotropicElasticity3D
  from torchfem.mesh import cube_hexa
  
  device = sys.argv[1]
  torch.set_default_device(device)
  torch.set_default_dtype(torch.float64)
  
  
  if __name__ == "__main__":
      N = 2
      material = IsotropicElasticity3D(E=1.0, nu=0.1)
      nodes, elements = cube_hexa(N + 1, N + 1, N + 1, N, N, N)
      model = Solid(nodes, elements, material)
      model.constraints[nodes[:, 0] == 0.0, :] = True
      model.forces[nodes[:, 0] == N, :] = torch.tensor([0.0, 0.0, -1.0])
  
      rho = torch.ones(len(model.elements), requires_grad=True)
  
      C0 = model.material.C.clone()
      model.material.C = torch.einsum("j,jkl->jkl", rho, C0)
  
      u, _, _, _, _ = model.solve(rtol=0.9)
      u.sum().backward()
      print(f"{rho.grad=}")
  ```
  
  ```shell
  python test_cube.py cpu
  rho.grad=tensor([110.1672,  14.7000,  54.9866,  69.8806,  18.8981,  13.1082,  16.4147,
           15.5916])
  
  python test_cube.py cuda:0
  rho.grad=tensor([353.6858,  90.6473, 206.1306, 238.2024, 592.6966, 410.5132, 512.7472,
          490.4626], device='cuda:0')
  ```

After the fix, cuda:0 returns the same as cpu.

- scipy minres argument changed from tol to rtol in a recent version so this code is compatible with only more recent scripy releases. Adding version specification to avoid errors.


