### PR TITLE
Add compression toggle to export_mesh

### DIFF
--- a/src/torchfem/io.py
+++ b/src/torchfem/io.py
@@ -1,4 +1,5 @@
 from os import PathLike
+from pathlib import Path
 from typing import Dict, List
 
 import numpy as np
@@ -19,6 +20,7 @@ def export_mesh(
     filename: str | PathLike,
     nodal_data: Dict[str, Tensor] = {},
     elem_data: Dict[str, List[Tensor]] = {},
+    compress: bool = True
 ):
     etype = mesh.etype.meshio_type
 
@@ -31,8 +33,15 @@ def export_mesh(
             for key, tensor_list in elem_data.items()
         },
     )
-    msh.write(filename)
-
+    suffix = Path(str(filename)).suffix.lower()
+    write_kwargs = {}
+    if suffix in {".vtu"}:
+        write_kwargs["compression"] = "zlib" if compress else None
+    elif suffix in {".xdmf", ".xmf"}:
+        write_kwargs["compression"] = "gzip" if compress else None
+        if compress:
+            write_kwargs["compression_opts"] = 4
+    msh.write(filename, **write_kwargs)
 
 def import_mesh(
     filename: PathLike, material: Material, thickness: float = 1.0


### PR DESCRIPTION
- torch-fem currently calls meshio.Mesh.write() without a way to disable writer compression
- VTU defaults to zlib compression in meshio, XDMF defaults to gzip/HDF5
- This PR adds compress: bool = True to keep current behavior, with compress=False disabling compression for supported formats